### PR TITLE
BUG: Exception during shutdown

### DIFF
--- a/switcher.py
+++ b/switcher.py
@@ -71,8 +71,8 @@ class Switcher:
     def display_step_handler(self, channel) -> None:
         self.step_display_mode()
 
-    @staticmethod
-    def end_gpio():
-        # Clean up on exit
-        # not used at the moment due to concerns that this may clobber the GPIO-attached display
-        GPIO.cleanup()
+    def end_gpio(self):
+        if platform.system() == 'Linux':
+            # Clean up on exit
+            # not used at the moment due to concerns that this may clobber the GPIO-attached display
+            GPIO.cleanup()

--- a/yesican.py
+++ b/yesican.py
@@ -43,7 +43,10 @@ class MainWindow:
         self.switcher = Switcher(len(self.frame_list))
 
     def shutdown(self) -> None:
-        self.switcher.end_gpio()
+        # if the can interface open fails, we can come through here without the switcher instantiated
+        if self.switcher:
+            self.switcher.end_gpio()
+
         self.presentation.shutdown()
 
     def get_window_height(self) -> int:


### PR DESCRIPTION
The first reason was because Switcher.end_gpio() didn't check that we are running on Linux, and so issued GPIO.cleanup() on Windows.

The second reason was because if the can adapter open fails, we call MainWindow.shutdown, and this called Switcher.end_gpio(), and at this point we don't have a Switcher object, so I've added a check.